### PR TITLE
Fix export

### DIFF
--- a/lib/Regex/FuzzyToken.pm6
+++ b/lib/Regex/FuzzyToken.pm6
@@ -100,6 +100,5 @@ sub EXPORT {
   );
 
   # Export the fuzzy token in its wrapped form
-  %( '&fuzzy' => &fuzzy )
-
+  Map.new( '&fuzzy' => &fuzzy )
 }


### PR DESCRIPTION
`Hash` conterizes it's values causing a routine to be exported as a
scalar. `Map` must be used instead.

The only reason the module worked all this time is because old implementation of `wrap` involved use of `CALL-ME` which acted as a fallback. With new `wrap` code there is no `CALL-ME` anymore.